### PR TITLE
chore: fix go 1.20 version

### DIFF
--- a/.github/workflows/proto-upgrade.yml
+++ b/.github/workflows/proto-upgrade.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: Clone Flipt into sub-directory
         run: gh repo clone flipt-io/flipt


### PR DESCRIPTION
Fixes the issue where `proto-upgrade` workflow is failing because the go version we are actually installing is go `1.2` instead of `1.20` 😲 

see: https://github.com/actions/setup-go/issues/361

> Acquiring go1.2.2

https://github.com/flipt-io/flipt-grpc-go/actions/runs/4669411177/jobs/8276772794#step:3:13