### PR TITLE
chore: deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The official GRPC Go client for [Flipt](https://github.com/markphelps/flipt).
 
+## ⚠️ Deprecated
+
+This client has been deprecated in favor of the [Flipt Go SDK](https://pkg.go.dev/go.flipt.io/flipt/sdk/go) which supports both GRPC and REST transports.
+
 ## Usage
 
 `go get -u go.flipt.io/flipt-grpc`


### PR DESCRIPTION
Deprecate this client in favor of the newer Go SDK